### PR TITLE
feat(CodeBlock): 增加代码块行号选项

### DIFF
--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -95,6 +95,10 @@
             代码块最大高度
             <input type="text" v-model="codeMaxHeight" placeholder="如: 300px" class="code-max-height-input" />
           </label>
+          <label>
+            <input type="checkbox" v-model="enableCodeLineNumber" />
+            代码块行号
+          </label>
         </div>
       </div>
 
@@ -140,6 +144,7 @@
             :enable-animate="enableAnimate"
             :enable-shiki="enableShiki"
             :enable-mermaid="enableMermaid"
+            :enable-code-line-number="enableCodeLineNumber"
             :is-dark="isDark"
             :show-code-block-header="showCodeBlockHeader"
             :sticky-code-block-header="enableCodeBlockHeaderSticky"
@@ -147,6 +152,7 @@
             :code-block-actions="codeBlockActions"
             :mermaid-actions="mermaidActions"
             :code-x-render="codeXRender"
+            
           >
             <!-- 自定义 HTML 标签插槽 -->
             <template #self-btn>
@@ -202,6 +208,7 @@ const enableCodeBlockHeaderSticky = useLocalStorage('x-md-playground-enableCodeB
 const codeMaxHeight = useLocalStorage('x-md-playground-codeMaxHeight', '')
 const enableShiki = useLocalStorage('x-md-playground-enableShiki', true)
 const enableMermaid = useLocalStorage('x-md-playground-enableMermaid', true)
+const enableCodeLineNumber = useLocalStorage('x-md-playground-enableCodeLineNumber', true)
 
 // 流式演示状态
 const isStreaming = ref(false)

--- a/packages/x-markdown/src/MarkdownRender/index.ts
+++ b/packages/x-markdown/src/MarkdownRender/index.ts
@@ -25,6 +25,7 @@ const markdownRendererProps = {
   },
   showCodeBlockHeader: { type: Boolean, default: true },
   stickyCodeBlockHeader: { type: Boolean, default: false },
+  enableCodeLineNumber: { type: Boolean, default: true },
   codeMaxHeight: { type: String, default: undefined },
   codeBlockActions: { type: Array as PropType<CodeBlockAction[]>, default: undefined },
   mermaidActions: { type: Array as PropType<MermaidAction[]>, default: undefined },

--- a/packages/x-markdown/src/MarkdownRender/types.d.ts
+++ b/packages/x-markdown/src/MarkdownRender/types.d.ts
@@ -13,6 +13,7 @@ export interface MarkdownContext {
   codeXRender?: Record<string, any>
   showCodeBlockHeader?: boolean
   stickyCodeBlockHeader?: boolean
+  enableCodeLineNumber?: boolean
   codeMaxHeight?: string
   codeBlockActions?: CodeBlockAction[]
   mermaidActions?: MermaidAction[]

--- a/packages/x-markdown/src/components/CodeBlock/CodeBlockPlain.vue
+++ b/packages/x-markdown/src/components/CodeBlock/CodeBlockPlain.vue
@@ -78,7 +78,17 @@
       </div>
     </div>
     <div class="x-md-code-body" :class="{ 'x-md-code-body--collapsed': collapsed }">
-      <pre class="x-md-plain-pre" :style="codeContainerStyle"><code class="x-md-code-content">{{ code }}</code></pre>
+      <pre class="x-md-plain-pre" :style="codeContainerStyle">
+        <code class="x-md-code-content" :class="{ 'x-md-code-content--lines': enableCodeLineNumber }">
+          <template v-if="enableCodeLineNumber">
+            <span v-for="(line, i) in textLines" :key="i" class="x-md-plain-line">
+              <span class="x-md-code-line-number" aria-hidden="true">{{ i + codeLineNumberStartResolved }}</span>
+              <span class="x-md-plain-line-text">{{ line }}</span>
+            </span>
+          </template>
+          <template v-else>{{ code }}</template>
+        </code>
+      </pre>
     </div>
   </div>
 </template>
@@ -94,6 +104,8 @@ interface CodeBlockPlainProps {
   showCodeBlockHeader?: boolean
   stickyCodeBlockHeader?: boolean
   codeMaxHeight?: string
+  enableCodeLineNumber?: boolean
+  codeLineNumberStart?: number
 }
 
 defineOptions({
@@ -112,9 +124,23 @@ const props = withDefaults(defineProps<CodeBlockPlainProps>(), {
   isDark: false,
   showCodeBlockHeader: true,
   stickyCodeBlockHeader: true,
+  enableCodeLineNumber: true,
+  codeLineNumberStart: 1,
 })
 
 const code = computed(() => props.code.trim())
+
+const codeLineNumberStartResolved = computed(() => {
+  if(typeof props.codeLineNumberStart !== 'number' || Number.isNaN(props.codeLineNumberStart)) return 1
+
+  return Math.floor(props.codeLineNumberStart)
+})
+
+const textLines = computed(() => {
+  const t = code.value
+  if (!t) return ['']
+  return t.split('\n')
+})
 
 const language = computed(() => props.language || 'text')
 
@@ -293,5 +319,38 @@ defineExpose({
 .x-md-code-content {
   display: block;
   white-space: pre;
+}
+
+.x-md-code-content--lines {
+  white-space: normal;
+}
+
+.x-md-plain-line {
+  display: flex;
+  align-items: flex-start;
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.x-md-code-line-number {
+  flex-shrink: 0;
+  min-width: 3ch;
+  padding-right: 1em;
+  margin-right: 0.25em;
+  text-align: right;
+  user-select: none;
+  color: rgba(100, 100, 100, 0.85);
+  font-variant-numeric: tabular-nums;
+}
+
+.x-md-code-block.x-md-code-block--dark .x-md-code-line-number {
+  color: rgba(200, 200, 200, 0.55);
+}
+
+.x-md-plain-line-text {
+  flex: 1;
+  min-width: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 </style>

--- a/packages/x-markdown/src/components/CodeBlock/SyntaxCodeBlock.vue
+++ b/packages/x-markdown/src/components/CodeBlock/SyntaxCodeBlock.vue
@@ -1,17 +1,32 @@
 <template>
-  <div class="x-md-syntax-code-block">
-    <pre v-if="showFallback" :style="codeContainerStyle"><code>{{ code }}</code></pre>
+  <div class="x-md-syntax-code-block" :class="{ 'x-md-syntax-code-block--dark': props.isDark }">
+    <pre v-if="showFallback" :style="codeContainerStyle" tabindex="0">
+      <code class="x-md-code-content">
+        <span v-for="(line, i) in fallbackLines" :key="i" class="x-md-code-line">
+          <span v-if="props.enableCodeLineNumber" class="x-md-code-line-number" aria-hidden="true">{{
+            i + codeLineNumberStartResolved
+          }}</span>
+          <span class="x-md-code-line-code">{{ line}}</span>
+        </span>
+      </code>
+    </pre>
     <pre v-else :class="['shiki', actualTheme]" :style="codeContainerStyle" tabindex="0">
       <code class="x-md-code-content">
         <span v-for="(line, i) in lines" :key="i" class="x-md-code-line">
-          <span v-if="!line.length">&nbsp;</span>
-          <span  
-            v-else 
-            v-for="(token, j) in line" 
-            :key="j" 
-            :style="getTokenStyle(token)"
-            :class="{ 'x-md-animated-word': props.enableAnimate }"
-          >{{ token.content }}</span>
+          <span v-if="props.enableCodeLineNumber" class="x-md-code-line-number" aria-hidden="true">{{
+            i + codeLineNumberStartResolved
+          }}</span>
+          <span class="x-md-code-line-code">
+            <span v-if="!line.length">&nbsp;</span>
+            <span
+              v-else
+              v-for="(token, j) in line"
+              :key="j"
+              :style="getTokenStyle(token)"
+              :class="{ 'x-md-animated-word': props.enableAnimate }"
+              >{{ token.content }}</span
+            >
+          </span>
         </span>
       </code>
     </pre>
@@ -33,6 +48,8 @@ const props = withDefaults(defineProps<SyntaxCodeBlockProps>(), {
   shikiTheme: () => ['vitesse-light', 'vitesse-dark'] as [BuiltinTheme, BuiltinTheme],
   isDark: false,
   enableAnimate: false,
+  enableCodeLineNumber: true,
+  codeLineNumberStart: 1,
 })
 
 const code = computed(() => props.code.trim())
@@ -81,6 +98,18 @@ const getTokenStyle = (token: ThemedToken): CSSProperties => {
 
 const showFallback = computed(() => !lines.value?.length)
 
+const codeLineNumberStartResolved = computed(() => {
+  if(typeof props.codeLineNumberStart !== 'number' || Number.isNaN(props.codeLineNumberStart)) return 1
+
+  return Math.floor(props.codeLineNumberStart)
+})
+
+const fallbackLines = computed(() => {
+  const t = code.value
+  if (!t) return ['']
+  return t.split('\n')
+})
+
 const codeContainerStyle = computed(() => ({
   ...preStyle.value,
   maxHeight: props.codeMaxHeight,
@@ -116,5 +145,28 @@ defineExpose({
   font-size: 14px;
   line-height: 1.5;
   display: flex;
+  align-items: flex-start;
+}
+
+.x-md-code-line-number {
+  flex-shrink: 0;
+  min-width: 3ch;
+  padding-right: 1em;
+  margin-right: 0.25em;
+  text-align: right;
+  user-select: none;
+  color: rgba(100, 100, 100, 0.85);
+  font-variant-numeric: tabular-nums;
+}
+
+.x-md-syntax-code-block--dark .x-md-code-line-number {
+  color: rgba(200, 200, 200, 0.55);
+}
+
+.x-md-code-line-code {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-wrap: wrap;
 }
 </style>

--- a/packages/x-markdown/src/components/CodeBlock/index.vue
+++ b/packages/x-markdown/src/components/CodeBlock/index.vue
@@ -100,6 +100,8 @@
         :color-replacements="props.colorReplacements"
         :code-max-height="props.codeMaxHeight"
         :enable-animate="props.enableAnimate"
+        :enable-code-line-number="props.enableCodeLineNumber"
+        :code-line-number-start="props.codeLineNumberStart"
       />
     </div>
   </div>
@@ -133,6 +135,8 @@ const props = withDefaults(defineProps<CodeBlockProps>(), {
   enableAnimate: false,        // 默认不启用动画
   codeBlockActions: undefined, // 默认无自定义操作按钮
   stickyCodeBlockHeader: true, // 默认启用sticky
+  enableCodeLineNumber: true, // 默认启用行号
+  codeLineNumberStart: 1, // 默认行号从1开始
 })
 
 const code = computed(() => props.code.trim())

--- a/packages/x-markdown/src/components/CodeBlock/types.d.ts
+++ b/packages/x-markdown/src/components/CodeBlock/types.d.ts
@@ -8,6 +8,9 @@ export interface SyntaxCodeBlockProps {
   colorReplacements?: Record<string, string>;
   codeMaxHeight?: string;
   enableAnimate?: boolean;
+
+  enableCodeLineNumber?: boolean;
+  codeLineNumberStart?: number;
 }
 
 export interface CodeBlockProps {
@@ -21,6 +24,8 @@ export interface CodeBlockProps {
   enableAnimate?: boolean;
   codeBlockActions?: CodeBlockAction[];
   stickyCodeBlockHeader?: boolean;
+  enableCodeLineNumber?: boolean;
+  codeLineNumberStart?: number;
 }
 
 export interface CodeBlockRaw {

--- a/packages/x-markdown/src/components/CodeX/index.vue
+++ b/packages/x-markdown/src/components/CodeX/index.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { defineComponent, h, defineAsyncComponent, type PropType } from 'vue'
+import { defineComponent, h, defineAsyncComponent, type PropType, computed } from 'vue'
 import type { BuiltinTheme } from 'shiki'
 import type { CodeBlockAction } from '../CodeBlock/types'
 import type { MermaidAction } from '../Mermaid/types'
@@ -25,6 +25,7 @@ export default defineComponent({
     },
     showCodeBlockHeader: { type: Boolean, default: true },
     stickyCodeBlockHeader: { type: Boolean, default: true },
+    enableCodeLineNumber: { type: Boolean, default: true },
     codeMaxHeight: { type: String, default: undefined },
     enableAnimate: { type: Boolean, default: false },
     enableShiki: { type: Boolean, default: true },
@@ -35,6 +36,11 @@ export default defineComponent({
   },
   setup(props, { slots }) {
     const { codeXRender } = props
+
+    const blockEnableCodeLineNumber = computed(() => {
+      if (props.raw?.inline) return false
+      return !!props.enableCodeLineNumber
+    })
 
     return (): ReturnType<typeof h> | null => {
       // 处理行内代码
@@ -108,6 +114,7 @@ export default defineComponent({
             showCodeBlockHeader: props.showCodeBlockHeader,
             stickyCodeBlockHeader: props.stickyCodeBlockHeader,
             codeMaxHeight: props.codeMaxHeight,
+            enableCodeLineNumber: blockEnableCodeLineNumber.value,
           },
           slots,
         )
@@ -125,6 +132,7 @@ export default defineComponent({
           codeMaxHeight: props.codeMaxHeight,
           enableAnimate: props.enableAnimate,
           codeBlockActions: props.codeBlockActions,
+          enableCodeLineNumber: blockEnableCodeLineNumber.value,
         },
         slots,
       )

--- a/packages/x-markdown/src/hooks/useComponents.ts
+++ b/packages/x-markdown/src/hooks/useComponents.ts
@@ -14,6 +14,7 @@ interface UseComponentsOptions {
   showCodeBlockHeader?: boolean
   stickyCodeBlockHeader?: boolean
   codeMaxHeight?: string
+  enableCodeLineNumber?: boolean
   codeBlockActions?: CodeBlockAction[]
   mermaidActions?: MermaidAction[]
   mermaidConfig?: Record<string, any>
@@ -33,6 +34,7 @@ function useComponents(props?: UseComponentsOptions) {
         showCodeBlockHeader: props?.showCodeBlockHeader,
         stickyCodeBlockHeader: props?.stickyCodeBlockHeader,
         codeMaxHeight: props?.codeMaxHeight,
+        enableCodeLineNumber: props?.enableCodeLineNumber,
         codeBlockActions: props?.codeBlockActions,
         mermaidActions: props?.mermaidActions,
         mermaidConfig: props?.mermaidConfig,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a configurable code block line numbers toggle to the playground that persists across sessions. Users can now control whether rendered code blocks display line numbers throughout the application. The feature defaults to enabled and applies across all code block renderers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->