### PR TITLE
fix(code-block): preserve layout with line number config

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ const content = ref('# Large Document\n...')
 | `enableBreaks` | `boolean` | `true` | 是否将换行符转换为 `<br>` |
 | `isDark` | `boolean` | `false` | 是否为深色模式 |
 | `showCodeBlockHeader` | `boolean` | `true` | 是否显示代码块头部 |
+| `enableCodeLineNumber` | `boolean` | `true` | 是否显示代码块行号 |
+| `codeLineNumberStart` | `number` | `1` | 代码块行号起始值 |
 | `codeMaxHeight` | `string` | `undefined` | 代码块最大高度，如 '300px' |
 | `codeBlockActions` | `CodeBlockAction[]` | `[]` | 代码块自定义操作按钮 |
 | `mermaidActions` | `MermaidAction[]` | `[]` | Mermaid 图表自定义操作按钮 |

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -99,6 +99,10 @@
             <input type="checkbox" v-model="enableCodeLineNumber" />
             代码块行号
           </label>
+          <label class="code-max-height-label">
+            行号起始值
+            <input type="number" v-model.number="codeLineNumberStart" min="0" class="code-max-height-input" />
+          </label>
         </div>
       </div>
 
@@ -145,6 +149,7 @@
             :enable-shiki="enableShiki"
             :enable-mermaid="enableMermaid"
             :enable-code-line-number="enableCodeLineNumber"
+            :code-line-number-start="codeLineNumberStart"
             :is-dark="isDark"
             :show-code-block-header="showCodeBlockHeader"
             :sticky-code-block-header="enableCodeBlockHeaderSticky"
@@ -209,6 +214,7 @@ const codeMaxHeight = useLocalStorage('x-md-playground-codeMaxHeight', '')
 const enableShiki = useLocalStorage('x-md-playground-enableShiki', true)
 const enableMermaid = useLocalStorage('x-md-playground-enableMermaid', true)
 const enableCodeLineNumber = useLocalStorage('x-md-playground-enableCodeLineNumber', true)
+const codeLineNumberStart = useLocalStorage('x-md-playground-codeLineNumberStart', 1)
 
 // 流式演示状态
 const isStreaming = ref(false)

--- a/packages/x-markdown/README.md
+++ b/packages/x-markdown/README.md
@@ -118,6 +118,8 @@ const content = ref('# Large Document\n...')
 | `enableBreaks`        | `boolean`           | `true`      | 是否将换行符转换为 `<br>`   |
 | `isDark`              | `boolean`           | `false`     | 是否为深色模式              |
 | `showCodeBlockHeader` | `boolean`           | `true`      | 是否显示代码块头部          |
+| `enableCodeLineNumber` | `boolean`           | `true`      | 是否显示代码块行号          |
+| `codeLineNumberStart` | `number`            | `1`         | 代码块行号起始值            |
 | `codeMaxHeight`       | `string`            | `undefined` | 代码块最大高度，如 '300px'  |
 | `codeBlockActions`    | `CodeBlockAction[]` | `[]`        | 代码块自定义操作按钮        |
 | `mermaidActions`      | `MermaidAction[]`   | `[]`        | Mermaid 图表自定义操作按钮  |

--- a/packages/x-markdown/src/MarkdownRender/index.ts
+++ b/packages/x-markdown/src/MarkdownRender/index.ts
@@ -26,6 +26,7 @@ const markdownRendererProps = {
   showCodeBlockHeader: { type: Boolean, default: true },
   stickyCodeBlockHeader: { type: Boolean, default: false },
   enableCodeLineNumber: { type: Boolean, default: true },
+  codeLineNumberStart: { type: Number, default: 1 },
   codeMaxHeight: { type: String, default: undefined },
   codeBlockActions: { type: Array as PropType<CodeBlockAction[]>, default: undefined },
   mermaidActions: { type: Array as PropType<MermaidAction[]>, default: undefined },

--- a/packages/x-markdown/src/MarkdownRender/types.d.ts
+++ b/packages/x-markdown/src/MarkdownRender/types.d.ts
@@ -14,6 +14,7 @@ export interface MarkdownContext {
   showCodeBlockHeader?: boolean
   stickyCodeBlockHeader?: boolean
   enableCodeLineNumber?: boolean
+  codeLineNumberStart?: number
   codeMaxHeight?: string
   codeBlockActions?: CodeBlockAction[]
   mermaidActions?: MermaidAction[]

--- a/packages/x-markdown/src/components/CodeBlock/CodeBlockPlain.vue
+++ b/packages/x-markdown/src/components/CodeBlock/CodeBlockPlain.vue
@@ -78,8 +78,12 @@
       </div>
     </div>
     <div class="x-md-code-body" :class="{ 'x-md-code-body--collapsed': collapsed }">
-      <pre class="x-md-plain-pre" :style="codeContainerStyle">
-        <code class="x-md-code-content" :class="{ 'x-md-code-content--lines': enableCodeLineNumber }">
+      <pre class="x-md-plain-pre" :style="codeContainerStyle" tabindex="0">
+        <code
+          class="x-md-code-content"
+          :class="{ 'x-md-code-content--lines': enableCodeLineNumber }"
+          :style="codeContentStyle"
+        >
           <template v-if="enableCodeLineNumber">
             <span v-for="(line, i) in textLines" :key="i" class="x-md-plain-line">
               <span class="x-md-code-line-number" aria-hidden="true">{{ i + codeLineNumberStartResolved }}</span>
@@ -94,7 +98,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, ref, type CSSProperties } from 'vue'
 import { useClipboard } from '@vueuse/core'
 
 interface CodeBlockPlainProps {
@@ -131,7 +135,7 @@ const props = withDefaults(defineProps<CodeBlockPlainProps>(), {
 const code = computed(() => props.code.trim())
 
 const codeLineNumberStartResolved = computed(() => {
-  if(typeof props.codeLineNumberStart !== 'number' || Number.isNaN(props.codeLineNumberStart)) return 1
+  if (typeof props.codeLineNumberStart !== 'number' || Number.isNaN(props.codeLineNumberStart)) return 1
 
   return Math.floor(props.codeLineNumberStart)
 })
@@ -147,6 +151,20 @@ const language = computed(() => props.language || 'text')
 const codeContainerStyle = computed(() => ({
   maxHeight: props.codeMaxHeight,
 }))
+
+const lineNumberWidth = computed(() => {
+  const firstLineNumber = codeLineNumberStartResolved.value
+  const lastLineNumber = firstLineNumber + Math.max(textLines.value.length, 1) - 1
+  const maxLineNumberLength = Math.max(String(firstLineNumber).length, String(lastLineNumber).length)
+  return `${maxLineNumberLength}ch`
+})
+
+const codeContentStyle = computed<CSSProperties>(
+  () =>
+    ({
+      '--x-md-code-line-number-width': lineNumberWidth.value,
+    }) as CSSProperties,
+)
 
 defineExpose({
   copy,
@@ -334,7 +352,7 @@ defineExpose({
 
 .x-md-code-line-number {
   flex-shrink: 0;
-  min-width: 3ch;
+  min-width: var(--x-md-code-line-number-width, 3ch);
   padding-right: 1em;
   margin-right: 0.25em;
   text-align: right;

--- a/packages/x-markdown/src/components/CodeBlock/SyntaxCodeBlock.vue
+++ b/packages/x-markdown/src/components/CodeBlock/SyntaxCodeBlock.vue
@@ -183,6 +183,5 @@ defineExpose({
   flex: 1;
   min-width: 0;
   display: flex;
-  flex-wrap: wrap;
 }
 </style>

--- a/packages/x-markdown/src/components/CodeBlock/SyntaxCodeBlock.vue
+++ b/packages/x-markdown/src/components/CodeBlock/SyntaxCodeBlock.vue
@@ -1,17 +1,17 @@
 <template>
   <div class="x-md-syntax-code-block" :class="{ 'x-md-syntax-code-block--dark': props.isDark }">
     <pre v-if="showFallback" :style="codeContainerStyle" tabindex="0">
-      <code class="x-md-code-content">
+      <code class="x-md-code-content" :style="codeContentStyle">
         <span v-for="(line, i) in fallbackLines" :key="i" class="x-md-code-line">
           <span v-if="props.enableCodeLineNumber" class="x-md-code-line-number" aria-hidden="true">{{
             i + codeLineNumberStartResolved
           }}</span>
-          <span class="x-md-code-line-code">{{ line}}</span>
+          <span class="x-md-code-line-code">{{ line || '\u00a0' }}</span>
         </span>
       </code>
     </pre>
     <pre v-else :class="['shiki', actualTheme]" :style="codeContainerStyle" tabindex="0">
-      <code class="x-md-code-content">
+      <code class="x-md-code-content" :style="codeContentStyle">
         <span v-for="(line, i) in lines" :key="i" class="x-md-code-line">
           <span v-if="props.enableCodeLineNumber" class="x-md-code-line-number" aria-hidden="true">{{
             i + codeLineNumberStartResolved
@@ -99,7 +99,7 @@ const getTokenStyle = (token: ThemedToken): CSSProperties => {
 const showFallback = computed(() => !lines.value?.length)
 
 const codeLineNumberStartResolved = computed(() => {
-  if(typeof props.codeLineNumberStart !== 'number' || Number.isNaN(props.codeLineNumberStart)) return 1
+  if (typeof props.codeLineNumberStart !== 'number' || Number.isNaN(props.codeLineNumberStart)) return 1
 
   return Math.floor(props.codeLineNumberStart)
 })
@@ -114,6 +114,22 @@ const codeContainerStyle = computed(() => ({
   ...preStyle.value,
   maxHeight: props.codeMaxHeight,
 }))
+
+const displayLineCount = computed(() => (showFallback.value ? fallbackLines.value.length : lines.value.length))
+
+const lineNumberWidth = computed(() => {
+  const firstLineNumber = codeLineNumberStartResolved.value
+  const lastLineNumber = firstLineNumber + Math.max(displayLineCount.value, 1) - 1
+  const maxLineNumberLength = Math.max(String(firstLineNumber).length, String(lastLineNumber).length)
+  return `${maxLineNumberLength}ch`
+})
+
+const codeContentStyle = computed<CSSProperties>(
+  () =>
+    ({
+      '--x-md-code-line-number-width': lineNumberWidth.value,
+    }) as CSSProperties,
+)
 
 defineExpose({
   lines,
@@ -150,7 +166,7 @@ defineExpose({
 
 .x-md-code-line-number {
   flex-shrink: 0;
-  min-width: 3ch;
+  min-width: var(--x-md-code-line-number-width, 3ch);
   padding-right: 1em;
   margin-right: 0.25em;
   text-align: right;

--- a/packages/x-markdown/src/components/CodeX/index.vue
+++ b/packages/x-markdown/src/components/CodeX/index.vue
@@ -26,6 +26,7 @@ export default defineComponent({
     showCodeBlockHeader: { type: Boolean, default: true },
     stickyCodeBlockHeader: { type: Boolean, default: true },
     enableCodeLineNumber: { type: Boolean, default: true },
+    codeLineNumberStart: { type: Number, default: 1 },
     codeMaxHeight: { type: String, default: undefined },
     enableAnimate: { type: Boolean, default: false },
     enableShiki: { type: Boolean, default: true },
@@ -115,6 +116,7 @@ export default defineComponent({
             stickyCodeBlockHeader: props.stickyCodeBlockHeader,
             codeMaxHeight: props.codeMaxHeight,
             enableCodeLineNumber: blockEnableCodeLineNumber.value,
+            codeLineNumberStart: props.codeLineNumberStart,
           },
           slots,
         )
@@ -133,6 +135,7 @@ export default defineComponent({
           enableAnimate: props.enableAnimate,
           codeBlockActions: props.codeBlockActions,
           enableCodeLineNumber: blockEnableCodeLineNumber.value,
+          codeLineNumberStart: props.codeLineNumberStart,
         },
         slots,
       )

--- a/packages/x-markdown/src/hooks/useComponents.ts
+++ b/packages/x-markdown/src/hooks/useComponents.ts
@@ -15,6 +15,7 @@ interface UseComponentsOptions {
   stickyCodeBlockHeader?: boolean
   codeMaxHeight?: string
   enableCodeLineNumber?: boolean
+  codeLineNumberStart?: number
   codeBlockActions?: CodeBlockAction[]
   mermaidActions?: MermaidAction[]
   mermaidConfig?: Record<string, any>
@@ -35,6 +36,7 @@ function useComponents(props?: UseComponentsOptions) {
         stickyCodeBlockHeader: props?.stickyCodeBlockHeader,
         codeMaxHeight: props?.codeMaxHeight,
         enableCodeLineNumber: props?.enableCodeLineNumber,
+        codeLineNumberStart: props?.codeLineNumberStart,
         codeBlockActions: props?.codeBlockActions,
         mermaidActions: props?.mermaidActions,
         mermaidConfig: props?.mermaidConfig,


### PR DESCRIPTION
Propagate codeLineNumberStart through MarkdownRenderer and keep code block line rendering consistent with the previous compact layout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration options to customize code block line numbering: toggle display on/off and set the starting line number.
  * Playground now includes a user setting for code line number start value with automatic persistence across sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->