### PR TITLE
feat: 代码块复制支持Clipboard api降级 兼容内网ip访问场景

### DIFF
--- a/packages/x-markdown/src/components/CodeBlock/index.vue
+++ b/packages/x-markdown/src/components/CodeBlock/index.vue
@@ -118,7 +118,7 @@ defineOptions({
   name: 'CodeBlock',
 })
 
-const { copy, copied } = useClipboard({ copiedDuring: 2000 })
+const { copy, copied } = useClipboard({ copiedDuring: 2000, legacy: true })
 
 const collapsed = ref(false)
 


### PR DESCRIPTION
有的客户没https 代码块复制用不了 
我这懒人也不想写自定义copy 所以开个降级 
TKS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved code block copy functionality by enabling compatibility with legacy clipboard behavior.
  * Copy button status updates now work more reliably across supported environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->