### PR TITLE
fix(code-block): enable legacy clipboard fallback for insecure contexts

### DIFF
--- a/packages/x-markdown/src/components/CodeBlock/CodeBlockPlain.vue
+++ b/packages/x-markdown/src/components/CodeBlock/CodeBlockPlain.vue
@@ -116,7 +116,7 @@ defineOptions({
   name: 'CodeBlockPlain',
 })
 
-const { copy, copied } = useClipboard({ copiedDuring: 2000 })
+const { copy, copied } = useClipboard({ copiedDuring: 2000, legacy: true })
 
 const collapsed = ref(false)
 

--- a/packages/x-markdown/src/components/CodeBlock/index.vue
+++ b/packages/x-markdown/src/components/CodeBlock/index.vue
@@ -118,7 +118,7 @@ defineOptions({
   name: 'CodeBlock',
 })
 
-const { copy, copied } = useClipboard({ copiedDuring: 2000 })
+const { copy, copied } = useClipboard({ copiedDuring: 2000, legacy: true })
 
 const collapsed = ref(false)
 

--- a/packages/x-markdown/src/components/Mermaid/index.vue
+++ b/packages/x-markdown/src/components/Mermaid/index.vue
@@ -64,7 +64,7 @@ function handleToggleCode() {
   showSourceCode.value = !showSourceCode.value
 }
 
-const { copy: copyCode, copied } = useClipboard({ copiedDuring: 1500 })
+const { copy: copyCode, copied } = useClipboard({ copiedDuring: 1500, legacy: true })
 
 function handleTabClick(tabName: string) {
   if (tabName === 'code' && !showSourceCode.value) {


### PR DESCRIPTION
close #63 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved code-copy functionality in code blocks and Mermaid diagrams by adding support for legacy clipboard behavior.
  * Preserved the copied-state indicator for 1.5 seconds after copying.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->