### PR TITLE
fix(code-block): render plain text fallback when shiki fails to load

### DIFF
--- a/packages/x-markdown/src/components/CodeBlock/SyntaxCodeBlock.vue
+++ b/packages/x-markdown/src/components/CodeBlock/SyntaxCodeBlock.vue
@@ -68,7 +68,11 @@ const resolveTokenStyle = (token: Parameters<typeof getTokenStyle>[0]): CSSPrope
   return getTokenStyle(token, props.colorReplacements)
 }
 
-const showFallback = computed(() => !lines.value?.length)
+// 与行内代码 (CodeLine) 保持一致：当高亮未产生任何 token 时（例如未安装 shiki /
+// shiki-stream 导致 useHighlight 动态 import 失败并回退为 [[]]）回退到纯文本渲染。
+// 原判断 !lines.value?.length 检查的是外层数组长度，而 [[]].length 为 1，
+// 导致 fallback 永远不触发、代码块内容显示为空（仅一个 &nbsp;）。
+const showFallback = computed(() => !lines.value.flat().length)
 
 const codeLineNumberStartResolved = computed(() => {
   if (typeof props.codeLineNumberStart !== 'number' || Number.isNaN(props.codeLineNumberStart)) return 1


### PR DESCRIPTION
## Summary
When shiki / shiki-stream is not installed, fenced code blocks rendered empty instead of falling back to plain text.

## Root cause
SyntaxCodeBlock.vue decided whether to fall back with \`!lines.value?.length\`. When shiki fails to load, useHighlight swallows the dynamic-import error and leaves \`lines\` as \`[[]]\`. Since \`[[]].length === 1\`, showFallback was always false, so the fallback never ran and the block showed only a &nbsp;.

The inline-code component CodeLine already uses \`lines.value.flat().length\` and falls back correctly — this makes the block-code path consistent with it.

## Fix
\`\`\`diff
- const showFallback = computed(() => !lines.value?.length)
+ const showFallback = computed(() => !lines.value.flat().length)
\`\`\`

## Test plan
- Without shiki/shiki-stream installed: fenced code blocks now show the raw code as plain text.
- With shiki installed: syntax highlighting works as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed code blocks appearing empty when syntax highlighting fails or returns empty token data.
  * Added fallback rendering for code content with empty highlighted lines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->